### PR TITLE
Fix payments logo header

### DIFF
--- a/src/components/Payments/PaymentsHeader.tsx
+++ b/src/components/Payments/PaymentsHeader.tsx
@@ -22,7 +22,7 @@ const TitleStyled = styled.div`
 
 function HeaderLogo() {
   // Import result is the URL of your image
-  return <img className="header-logo" src="https://anypayx.com/app/assets/assets/images/anypay-logo.png" alt="Logo" style={{width:"60px",float:"right"}}/>;
+  return <img className="header-logo" src="https://anypayx.com/app/assets/images/anypay-logo.png" alt="Logo" style={{width:"60px",float:"right"}}/>;
 }
 
 


### PR DESCRIPTION
An extra /assets added breaks logo loading on the frontend